### PR TITLE
add hadoop-2.8 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2751,6 +2751,13 @@
     </profile>
 
     <profile>
+        <id>hadoop-2.8</id>
+        <properties>
+            <hadoop.version>2.8.5</hadoop.version>
+            <curator.version>2.8.0</curator.version>
+        </properties>
+    </profile>
+    <profile>
       <id>hadoop-3.1</id>
       <properties>
         <hadoop.version>3.1.0</hadoop.version>


### PR DESCRIPTION
Add a profile for using Hadoop 2.8.5 required for AWS Glue compatibility.

@nodirhiya what else do we need for a working build?